### PR TITLE
Wait to stop before restarting during rollover

### DIFF
--- a/src/Recorder/IcecastMetadataArchiveRecorder.js
+++ b/src/Recorder/IcecastMetadataArchiveRecorder.js
@@ -53,7 +53,7 @@ class IcecastMetadataArchiveRecorder extends IcecastMetadataRecorder {
   }
 
   _rollover() {
-    super.stop();
+    const stopped = super.stop();
 
     const archiver = new ArchiveRotator({
       archivePath: this._archivePath,
@@ -61,7 +61,7 @@ class IcecastMetadataArchiveRecorder extends IcecastMetadataRecorder {
       filesToArchive: this._fileNames,
     });
 
-    archiver.rotate().then(() => this.record());
+    stopped.then(() => archiver.rotate()).then(() => this.record());
   }
 }
 

--- a/src/StreamRecorder/StreamRecorder.js
+++ b/src/StreamRecorder/StreamRecorder.js
@@ -90,11 +90,11 @@ const main = () => {
     process.exit(1);
   }
 
-  recorderInstances.forEach((recorder) => recorder.record());
-
   process.on("SIGQUIT", signalHandler);
   process.on("SIGTERM", signalHandler);
   process.on("SIGINT", signalHandler);
+
+  recorderInstances.forEach((recorder) => recorder.record());
 };
 
 main();

--- a/src/StreamRecorder/get-args.js
+++ b/src/StreamRecorder/get-args.js
@@ -120,7 +120,7 @@ const getArgs = () =>
           streams: {
             type: "array",
             describe:
-              "JSON Array containing a list of streams to record. \nRequired: {endpoint, output, name} \nOptional: {output-path, cue-rollover}",
+              "JSON Array containing a list of streams to record. \nRequired: {endpoint, output} \nOptional: {name, output-path, cue-rollover, date-entries, prepend-date}",
           },
         })
     )
@@ -145,7 +145,7 @@ const getArgs = () =>
             streams: {
               type: "array",
               describe:
-                "JSON Array containing a list of streams to archive. \nRequired: {endpoint, output, name} \nOptional: {output-path, archive-interval, archive-path, cue-rollover}",
+                "JSON Array containing a list of streams to archive. \nRequired: {endpoint, output} \nOptional: {name, output-path, archive-interval, archive-path, cue-rollover, date-entries, prepend-date}",
             },
           })
           .example([
@@ -159,6 +159,9 @@ const getArgs = () =>
             ],
           ])
     )
+    .config("config", (configPath) => {
+      return JSON.parse(fs.readFileSync(configPath, "utf-8"));
+    })
     .options({
       output: {
         alias: "o",
@@ -187,7 +190,6 @@ const getArgs = () =>
         default: false,
       },
       "prepend-date": {
-        alias: "p",
         describe:
           "Prepend an ISO date to the TITLE of each cue entry (i.e. YYYY-MM-DDTHH:MM:SS.SSSZ)",
         type: "boolean",
@@ -209,9 +211,6 @@ const getArgs = () =>
       "--version": {
         hidden: true,
       },
-    })
-    .config("config", (configPath) => {
-      return JSON.parse(fs.readFileSync(configPath, "utf-8"));
     })
     .wrap(argv.terminalWidth()).argv;
 

--- a/test/Recorder/IcecastMetadataRecorder.test.js
+++ b/test/Recorder/IcecastMetadataRecorder.test.js
@@ -53,19 +53,16 @@ describe("Given the IcecastMetadataRecorder", () => {
 
     fetch.mockResolvedValue({ headers, body });
 
-    const metadataRecorder = new IcecastMetadataRecorder(
-      {
-        output: `${params.actualPath}${params.expectedFileName}.${params.expectedFileFormat}`,
-        dateEntries: params.expectedDateEntries,
-        prependDate: params.expectedPrependDate,
-        name: params.expectedStreamTitle,
-        endpoint: "https://example.com",
-        cueRollover: params.expectedCueRollover,
-      },
-      done
-    );
+    const metadataRecorder = new IcecastMetadataRecorder({
+      output: `${params.actualPath}${params.expectedFileName}.${params.expectedFileFormat}`,
+      dateEntries: params.expectedDateEntries,
+      prependDate: params.expectedPrependDate,
+      name: params.expectedStreamTitle,
+      endpoint: "https://example.com",
+      cueRollover: params.expectedCueRollover,
+    });
 
-    metadataRecorder.record();
+    metadataRecorder.record().then(() => done());
   };
 
   describe("Given no cue rollover", () => {


### PR DESCRIPTION
FIX:

Uses promise to wait for the recorder to stop and close files before starting to record again during an archive rollover.