### PR TITLE
Refactor steps to use continuation pattern

### DIFF
--- a/src/Parser/BufferArray.js
+++ b/src/Parser/BufferArray.js
@@ -3,6 +3,7 @@
  */
 class BufferArray {
   constructor() {
+    this._totalBytes = 0;
     this.init();
 
     // Use fast buffer allocation if this is a NodeJS runtime or Uint8Array if a browser runtime
@@ -16,7 +17,7 @@ class BufferArray {
    */
   init() {
     this._buffers = [];
-    this._totalBytes = 0;
+    this._length = 0;
     this._currentLength = 0;
     this._currentIndex = -1;
   }
@@ -25,6 +26,13 @@ class BufferArray {
    * @type {number} Length of all stored data in bytes
    */
   get length() {
+    return this._length;
+  }
+
+  /**
+   * @type {number} Length of total bytes stored in the buffer since instantiation
+   */
+  get totalBytes() {
     return this._totalBytes;
   }
 
@@ -34,7 +42,7 @@ class BufferArray {
   get readAll() {
     let offset = 0;
     this._buffers.length && this._trimTail();
-    const returnBuffer = this._newBuffer(this._totalBytes);
+    const returnBuffer = this._newBuffer(this._length);
 
     this._buffers.forEach((buf) => {
       returnBuffer.set(buf, offset);
@@ -62,6 +70,7 @@ class BufferArray {
   append(data) {
     this._buffers[this._currentIndex].set(data, this._currentLength);
     this._currentLength += data.length;
+    this._length += data.length;
     this._totalBytes += data.length;
   }
 

--- a/src/Parser/BufferArray.js
+++ b/src/Parser/BufferArray.js
@@ -41,7 +41,8 @@ class BufferArray {
    */
   get readAll() {
     let offset = 0;
-    this._buffers.length && this._trimTail();
+    this._trimTail();
+
     const returnBuffer = this._newBuffer(this._length);
 
     this._buffers.forEach((buf) => {
@@ -57,7 +58,8 @@ class BufferArray {
    * @param {number} length Bytes to allocate for the buffer
    */
   addBuffer(length) {
-    this._buffers.length && this._trimTail();
+    this._trimTail();
+
     this._buffers.push(this._newBuffer(length));
     this._currentLength = 0;
     this._currentIndex++;
@@ -68,16 +70,23 @@ class BufferArray {
    * @param {Uint8Array} data Data to append
    */
   append(data) {
+    this._buffers.length || this.addBuffer(data.length);
     this._buffers[this._currentIndex].set(data, this._currentLength);
+
     this._currentLength += data.length;
     this._length += data.length;
     this._totalBytes += data.length;
   }
 
   _trimTail() {
-    this._buffers[this._currentIndex] = this._buffers[
-      this._currentIndex
-    ].subarray(0, this._currentLength);
+    if (
+      this._buffers.length &&
+      this._buffers[this._currentIndex].length !== this._currentLength
+    ) {
+      this._buffers[this._currentIndex] = this._buffers[
+        this._currentIndex
+      ].subarray(0, this._currentLength);
+    }
   }
 
   _newBuffer(length) {

--- a/src/Parser/IcecastMetadataParser.js
+++ b/src/Parser/IcecastMetadataParser.js
@@ -118,7 +118,7 @@ class IcecastMetadataParser {
       for (let match of metaString.matchAll(
         /(?<key>[ -~]+?)='(?<val>[ -~]*?)(;$|';|'$|$)/g
       )) {
-        metadata[match.groups.key] = match.groups.val;
+        metadata[match["groups"]["key"]] = match["groups"]["val"];
       }
     } catch (e) {
       if (typeof metaString !== "string") {

--- a/test/Parser/IcecastMetadataParser.test.js
+++ b/test/Parser/IcecastMetadataParser.test.js
@@ -107,7 +107,7 @@ describe("Icecast Metadata Parser", () => {
       });
       expect(mockOnMetadata.mock.calls[2]).toEqual(undefined);
     };
-    it("should return the correct audio given it is read in chunks larger than the metaint", () => {
+    it("should return the correct audio given it is read in chunks smaller than the metaint", () => {
       readChunks(15999);
       expect(
         Buffer.compare(icecastMetadataParser.stream, expectedAudio)
@@ -115,7 +115,7 @@ describe("Icecast Metadata Parser", () => {
       expectMetadata();
     });
 
-    it("should return the correct audio given it is read in chunks smaller than the metaint", () => {
+    it("should return the correct audio given it is read in chunks larger than the metaint", () => {
       readChunks(16001);
       expect(
         Buffer.compare(icecastMetadataParser.stream, expectedAudio)


### PR DESCRIPTION
> Remove switch case and use continuation pattern to select the next step
> More efficiently allocate buffers