### PR TITLE
Detect Icy-MetaInt if CORS dissallows reading the header

### DIFF
--- a/src/demo/src/Player/Player.jsx
+++ b/src/demo/src/Player/Player.jsx
@@ -27,7 +27,7 @@ const useMetadataPlayer = (station, onMetadataUpdate, audioElement) => {
   const play = useCallback(() => {
     onMetadataUpdate(LOADING);
     setIsPlaying(true);
-    metadataPlayer.play(station.endpoint, station.metaInt);
+    metadataPlayer.play(station.endpoint);
   }, [onMetadataUpdate, metadataPlayer, station]);
 
   const stop = useCallback(() => {

--- a/src/demo/src/icecast/MetadataPlayer.js
+++ b/src/demo/src/icecast/MetadataPlayer.js
@@ -99,7 +99,7 @@ export default class MetadataPlayer {
     }
   }
 
-  play(endpoint, icyMetaInt) {
+  play(endpoint) {
     this._playing = true;
 
     this.fetchStream(endpoint)
@@ -108,7 +108,6 @@ export default class MetadataPlayer {
         this._isInitialMetadata = true;
 
         await new IcecastReadableStream(res, {
-          icyMetaInt,
           onStream: this._onStream,
           onMetadata: (value) => {
             this._isInitialMetadata

--- a/src/demo/src/icecast/MetadataPlayer.js
+++ b/src/demo/src/icecast/MetadataPlayer.js
@@ -108,6 +108,7 @@ export default class MetadataPlayer {
         this._isInitialMetadata = true;
 
         await new IcecastReadableStream(res, {
+          icyDetectionTimeout: 6000,
           onStream: this._onStream,
           onMetadata: (value) => {
             this._isInitialMetadata

--- a/src/demo/src/stations.json
+++ b/src/demo/src/stations.json
@@ -15,237 +15,203 @@
     "name": "Radio Cumbernauld",
     "description": "Broadcasting local news and music from Cumbernauld Scotland",
     "link": "https://www.radiocumbernauld.uk/",
-    "endpoint": "https://audio-edge-p6jke.yyz.d.radiomast.io/ebca0c3d-4178-4386-88a1-4db6b7d9e291",
-    "metaInt": 16384
+    "endpoint": "https://audio-edge-p6jke.yyz.d.radiomast.io/ebca0c3d-4178-4386-88a1-4db6b7d9e291"
   },
   {
     "name": "1RadioLounge",
     "description": "24/7 h. relax music...chill, ambient...",
     "link": "http://1radiolounge.playtheradio.com/",
-    "endpoint": "https://streaming211.radionomy.com/1RadioLounge_64.aac",
-    "metaInt": 16000
+    "endpoint": "https://streaming211.radionomy.com/1RadioLounge_64.aac"
   },
   {
     "name": "Jazz4ever",
     "description": "An accurate selection of Jazz, Fusion and Funky-Jazz with a sprinkle of \"sparkly\" Smooth Jazz.",
     "link": "http://jazz4ever.net/",
-    "endpoint": "https://streaming211.radionomy.com/Jazz4ever",
-    "metaInt": 16000
+    "endpoint": "https://streaming211.radionomy.com/Jazz4ever"
   },
   {
     "name": "Radio BluesFlac",
     "description": "Broadcasting in FLAC to give the listeners the authentic CD quality sound the artists want.",
     "link": "https://bluesflac.com/",
-    "endpoint": "https://audio-edge-fp8o9.yyz.d.radiomast.io/radioblues-flac",
-    "metaInt": 524288
+    "endpoint": "https://audio-edge-fp8o9.yyz.d.radiomast.io/radioblues-flac"
   },
   {
     "name": "90.9 Jazzy rádió - Jazzy Cool",
     "description": "The only Hungarian radio playing soul, swing, lounge and jazz beside smooth jazz hits.",
     "link": "https://jazzy.hu/",
-    "endpoint": "https://s04.diazol.hu:9530/live.mp3",
-    "metaInt": 16000
+    "endpoint": "https://s04.diazol.hu:9530/live.mp3"
   },
   {
     "name": "90.9 Jazzy rádió - Jazzy Groove",
     "description": "The only Hungarian radio playing soul, swing, lounge and jazz beside smooth jazz hits.",
     "link": "https://jazzy.hu/",
-    "endpoint": "https://s04.diazol.hu:9510/live.mp3",
-    "metaInt": 16000
+    "endpoint": "https://s04.diazol.hu:9510/live.mp3"
   },
   {
     "name": "90.9 Jazzy rádió - Jazzy Soul",
     "description": "The only Hungarian radio playing soul, swing, lounge and jazz beside smooth jazz hits.",
     "link": "https://jazzy.hu/",
-    "endpoint": "https://s04.diazol.hu:9520/live.mp3",
-    "metaInt": 16000
+    "endpoint": "https://s04.diazol.hu:9520/live.mp3"
   },
   {
     "name": "90.9 Jazzy Rádió",
     "description": "The only Hungarian radio playing soul, swing, lounge and jazz beside smooth jazz hits.",
     "link": "https://jazzy.hu/",
-    "endpoint": "https://s04.diazol.hu:9500/live.mp3",
-    "metaInt": 16000
+    "endpoint": "https://s04.diazol.hu:9500/live.mp3"
   },
   {
     "name": "Radio Paradise Main (FLAC)",
     "description": "RP is a blend of many styles and genres of music, carefully selected and mixed by two real human beings.",
     "link": "https://radioparadise.com/",
-    "endpoint": "https://stream.radioparadise.com/flacm",
-    "metaInt": 524288
+    "endpoint": "https://stream.radioparadise.com/flacm"
   },
   {
     "name": "Radio Paradise Mellow (FLAC)",
     "description": "RP is a blend of many styles and genres of music, carefully selected and mixed by two real human beings.",
     "link": "https://radioparadise.com/",
-    "endpoint": "https://stream.radioparadise.com/mellow-flacm",
-    "metaInt": 524288
+    "endpoint": "https://stream.radioparadise.com/mellow-flacm"
   },
   {
     "name": "Radio Paradise Rock (FLAC)",
     "description": "RP is a blend of many styles and genres of music, carefully selected and mixed by two real human beings.",
     "link": "https://radioparadise.com/",
-    "endpoint": "https://stream.radioparadise.com/rock-flacm",
-    "metaInt": 524288
+    "endpoint": "https://stream.radioparadise.com/rock-flacm"
   },
   {
     "name": "Radio Paradise World/Etc (AAC 320)",
     "description": "RP is a blend of many styles and genres of music, carefully selected and mixed by two real human beings.",
     "link": "https://radioparadise.com/",
-    "endpoint": "https://stream.radioparadise.com/world-etc-320",
-    "metaInt": 16000
+    "endpoint": "https://stream.radioparadise.com/world-etc-320"
   },
   {
     "name": "OroyaWave",
     "description": "Alternative Rock Brit Pop Chillwave Coldwave Darkwave Deathrock Dream Pop EBM Electroclash Ethereal Experimental Glam Goth Rock Indie Rock Italo-Disco Minimal New Wave No Wave Post-Punk Punk Synth-Pop Synthwave Shoegaze Techno Vaporwave",
     "link": "http://www.oroyawave.com/",
-    "endpoint": "https://streamingv2.shoutcast.com/oroyawave",
-    "metaInt": 16000
+    "endpoint": "https://streamingv2.shoutcast.com/oroyawave"
   },
   {
     "name": "OroyaWave-Minimal",
     "description": "minimal wave minimal electronic minimal synth coldwave new wave technopop synthpop electropunk electroclash synthwave retrowave outrun darksynth cyberpunk and some vaporwave musics.",
     "link": "http://www.oroyawave.com/",
-    "endpoint": "https://streamingv2.shoutcast.com/oroyawave-minimal",
-    "metaInt": 16000
+    "endpoint": "https://streamingv2.shoutcast.com/oroyawave-minimal"
   },
   {
     "name": "Radioparty.pl",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanalglowny.html",
-    "endpoint": "https://s2.radioparty.pl:8000/stream",
-    "metaInt": 16384
+    "endpoint": "https://s2.radioparty.pl:8000/stream"
   },
   {
     "name": "Radioparty.pl - House",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanalhouse.html",
-    "endpoint": "https://s1.radioparty.pl:8000/house",
-    "metaInt": 16384
+    "endpoint": "https://s1.radioparty.pl:8000/house"
   },
   {
     "name": "Radioparty.pl - Trance",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanaltrance.html",
-    "endpoint": "https://s2.radioparty.pl:8015/trance",
-    "metaInt": 16384
+    "endpoint": "https://s2.radioparty.pl:8015/trance"
   },
   {
     "name": "Radioparty.pl - Vocal Trance",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanalvtrance.html",
-    "endpoint": "https://s2.radioparty.pl:8015/vocaltrance",
-    "metaInt": 16384
+    "endpoint": "https://s2.radioparty.pl:8015/vocaltrance"
   },
   {
     "name": "Radioparty.pl - DJ Mixes",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanaldjmixes.html",
-    "endpoint": "https://s1.radioparty.pl:8000/djmixes",
-    "metaInt": 16000
+    "endpoint": "https://s1.radioparty.pl:8000/djmixes"
   },
   {
     "name": "Radioparty.pl - Energy 2000",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanalenergy2000.html",
-    "endpoint": "https://s1.radioparty.pl:8000/energy2000",
-    "metaInt": 16384
+    "endpoint": "https://s1.radioparty.pl:8000/energy2000"
   },
   {
     "name": "Radioparty.pl - Energy 2000 aac+",
     "description": "Techno, Dance, Club, Hands Up, House, Trance. Najlepsza klubowa muzyka w sieci. The best radio with club music.",
     "link": "https://radioparty.pl/kanalenergy2000.html",
-    "endpoint": "https://s2.radioparty.pl:8040/energy2000",
-    "metaInt": 16384
+    "endpoint": "https://s2.radioparty.pl:8040/energy2000"
   },
   {
     "name": "Dance Wave!",
     "description": "All Dance from 2000. Global dance radio station. The hottest Dance and Club Music from across the Planet!",
     "link": "https://dancewave.online/",
-    "endpoint": "https://dancewave.online/dance.mp3",
-    "metaInt": 16384
+    "endpoint": "https://dancewave.online/dance.mp3"
   },
   {
     "name": "Dance Wave! aac+",
     "description": "All Dance from 2000. Global dance radio station. The hottest Dance and Club Music from across the Planet!",
     "link": "https://dancewave.online/",
-    "endpoint": "https://dancewave.online/dance.aac",
-    "metaInt": 16384
+    "endpoint": "https://dancewave.online/dance.aac"
   },
   {
     "name": "Dance Wave Retro!",
     "description": "All Dance before 2000!",
     "link": "https://retro.dancewave.online/",
-    "endpoint": "https://retro.dancewave.online/retrodance.mp3",
-    "metaInt": 16384
+    "endpoint": "https://retro.dancewave.online/retrodance.mp3"
   },
   {
     "name": "Metro DANCE! Radio",
     "description": "Metro Dance Radio - home station of the morning show BODRA SMYANA (Cool Shift) broadcasted live every weekday morning 7 - 11 am and rebroadcasted through all Metro Cast Stations as well as on the major local FM outlets in Bulgaria.",
     "link": "https://dab.bg/radiochannel/metro/",
-    "endpoint": "http://eu1.reliastream.com:7017/MDR",
-    "metaInt": 16000
+    "endpoint": "http://eu1.reliastream.com:7017/MDR"
   },
   {
     "name": "Sama Radio Senegal",
     "description": "Good Vibes from Senegal West Africa! Sama Radio Dakar Senegal créée en Août 2013. Avec un groupe de jeunes ambitieux Sénégalais elle est aujourd hui la première chaîne indépendante et qui résume l ensemble du Paysage médiatique Sénégalais.",
     "link": "https://www.sunufm.com/samaradio/",
-    "endpoint": "https://streamingv2.shoutcast.com/SamaRadio",
-    "metaInt": 16000
+    "endpoint": "https://streamingv2.shoutcast.com/SamaRadio"
   },
   {
     "name": "ABC Piano",
     "description": "Only Piano Classical Music with Bach, Mozart, Beethoven, Rachmaninov, Debussy, Chopin, ...",
     "link": "https://www.radionomy.com/en/radio/abc-Piano",
-    "endpoint": "https://streaming211.radionomy.com/ABC-Piano",
-    "metaInt": 16000
+    "endpoint": "https://streaming211.radionomy.com/ABC-Piano"
   },
   {
     "name": "Atmospheres Radio",
     "description": "Music by students, staff and friends of the Royal Welsh College of Music and Drama",
     "link": "https://streaming.galaxywebsolutions.com/AudioPlayer/9040",
-    "endpoint": "https://streaming.galaxywebsolutions.com:9040/stream",
-    "metaInt": 16000
+    "endpoint": "https://streaming.galaxywebsolutions.com:9040/stream"
   },
   {
     "name": "HAWK Radio - Hilbert College",
     "description": "Modern Music from Hip Hop to Rock!",
     "link": "https://www.hilbert.edu/academics/undergraduate-programs/dmac/hawk-radio",
-    "endpoint": "https://streamingv2.shoutcast.com/HAWK-Radio-Hilbert-College?icy=http",
-    "metaInt": 16000
+    "endpoint": "https://streamingv2.shoutcast.com/HAWK-Radio-Hilbert-College?icy=http"
   },
   {
     "name": "AIFR Alverno Inferno Free Radio",
     "description": "Alverno College On-Line Radio Station",
     "link": "http://www-staging.alverno.edu/technology/mediahub/aifr.php",
-    "endpoint": "https://pavo.prostreaming.net:8022/stream",
-    "metaInt": 16000
+    "endpoint": "https://pavo.prostreaming.net:8022/stream"
   },
   {
     "name": "TheIndieBlend",
     "description": "Music. Discovery. Unleashed. Here's an Indie station that mixes it up -- pulling only the best songs played by KCRW-FM Los Angeles DJ Sticky/past WVUM-FM Miami DJ Tom Jackson Radio Eins 95.8 FM Berlin",
     "link": "http://theindieblend.playtheradio.com/",
-    "endpoint": "https://streaming307.radionomy.com/TheIndieBlend?icy=http",
-    "metaInt": 16000
+    "endpoint": "https://streaming307.radionomy.com/TheIndieBlend?icy=http"
   },
   {
     "name": "CiTR Live",
     "description": "CiTR 101.9FM/Discorder Magazine is the campus radio station and magazine of the University of British Columbia-Vancouver, broadcasting from traditional unceded Musqueam territory and streaming online",
     "link": "https://www.citr.ca/",
-    "endpoint": "https://stream.kanefm.com:1037/listen",
-    "metaInt": 16000
+    "endpoint": "https://stream.kanefm.com:1037/listen"
   },
   {
     "name": "Lo Nuestro 102.1",
     "description": "La mejor música típica de Panamá.",
     "link": "https://www.fmlonuestro.com/",
-    "endpoint": "https://www.streaming507.net:8136/stream",
-    "metaInt": 16000
+    "endpoint": "https://www.streaming507.net:8136/stream"
   },
   {
     "name": "Andean Music",
     "description": "Folklore Andean Acoustic Electronic Underground",
-    "endpoint": "https://streamingv2.shoutcast.com/andeanmusic?icy=http",
-    "metaInt": 16000
+    "endpoint": "https://streamingv2.shoutcast.com/andeanmusic?icy=http"
   }
 ]

--- a/src/icecast-metadata-js/README.md
+++ b/src/icecast-metadata-js/README.md
@@ -24,8 +24,9 @@ A generator that takes in raw icecast response data and return stream data and m
 ### Usage
 
 1. To use `IcecastMetadataReader`, create a new instance with the `Icy-MetaInt` header from the Icecast response as well as the optional `onStream` and `onMetadata` callbacks.
+   * If `icyMetaInt` is falsy, for example if the CORS policy does not allow clients to read the `Icy-MetaInt` header, then `IcecastMetadataReader` will attempt to detect the metadata interval based on the incoming request data.
 
-   *Note: The GET request to the Icecast server must contain a `Icy-Metadata: 1` header to    enable metadata.*
+   *The GET request to the Icecast server must contain a `Icy-Metadata: 1` header to enable ICY metadata.*
    
    <pre>
    const headers = myHTTPResponse.headers;
@@ -108,8 +109,19 @@ A generator that takes in raw icecast response data and return stream data and m
 
 ### Methods
 
-`const icecastReader = new IcecastMetadataReader({metaInt, onStream, onMetadata})`
+`const icecastReader = new IcecastMetadataReader({icyMetaInt, onStream, onMetadata})`
 
+* `new IcecastMetadataReader({icyMetaInt, icyDetectionTimeout, onStream, onMetadata})`
+  * `icyMetaInt`
+    * ICY Metadata interval read from `Icy-MetaInt` header in the response
+  * `icyDetectionTimeout`
+    * Duration in milliseconds to search for metadata if icyMetaInt isn't passed in
+    * Set to `0` to disable metadata detection
+    * default: `2000`
+  * `onStream`
+    * Async callback when stream data is returned
+  * `onMetadata`
+    * Async callback when stream data is returned
 * `icecastReader.iterator(data: Uint8Array)`
   * Takes in a byte array of raw icecast response body
   * Returns an Iterator that can be used in a `for ...of` loop to read stream or metadata
@@ -240,7 +252,7 @@ A NodeJS Writable stream that exposes stream and metadata via NodeJS Readable st
    </pre>
 
 ### Methods
-`const icecastStream = new IcecastMetadataStream({icyBr, icyMetaInt})`
+`const icecastStream = new IcecastMetadataStream({icyBr, icyMetaInt, icyDetectionTimeout})`
 
 * `icecastStream.stream`
   * Gets the Readable for `stream` data
@@ -261,7 +273,7 @@ A Browser ReadableStream wrapper for IcecastMetadataReader. The `IcecastReadable
     Notes: 
     * The GET request to the Icecast server must contain the `Icy-Metadata: 1` header to enable metadata.
       * CORS must allow the `Icy-Metadata` header. Without this header, metadata is not returned in the Icecast response.
-    * An invalid CORS policy on the Icecast server may prevent the `Icy-MetaInt` header from being read. To work around this, manually determine the metadata interval and pass it into the `icyMetaInt` option
+    * An inadequate CORS policy on the Icecast server may prevent the `Icy-MetaInt` header from being read. To work around this, `IcecastMetadataReader` will attempt to detect the metadata interval. Alternatively, the metadata interval can be manually determined an passed into the `icyMetaInt` option.
     * See the [Troublshooting](#troublshooting) section for more information on CORS.
    
     <pre>
@@ -286,8 +298,13 @@ A Browser ReadableStream wrapper for IcecastMetadataReader. The `IcecastReadable
     </pre>
 
 ### Methods
-`const icecastReadable = new IcecastReadableStream(fetchResponse, {icyMetaInt, onStream, onMetadata})`
+`const icecastReadable = new IcecastReadableStream(fetchResponse, options)`
 
+* `new IcecastReadableStream(fetchResponse, options)`
+  * `fetchResponse`
+    * Response object from the `fetch` API
+  * `options`
+    * See the constructor parameters for `IcecastMetadataReader`
 * `icecastStream.startReading`
   * Starts reading and parsing the response. Resolves once response had ended.
   * `onStream` is called and awaited when stream data is discovered

--- a/src/icecast-metadata-js/package-lock.json
+++ b/src/icecast-metadata-js/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "icecast-metadata-js",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/icecast-metadata-js/package.json
+++ b/src/icecast-metadata-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icecast-metadata-js",
-  "version": "0.0.2",
+  "version": "0.1.0",
   "description": "Library for Browser and NodeJS that reads, parses, and synchronizes icy metadata",
   "keywords": [
     "icecast",

--- a/src/icecast-metadata-js/package.json
+++ b/src/icecast-metadata-js/package.json
@@ -31,7 +31,7 @@
   "bugs": {
     "url": "https://github.com/eshaz/icecast-metadata-js/issues"
   },
-  "homepage": "https://github.com/eshaz/icecast-metadata-js#readme",
+  "homepage": "https://github.com/eshaz/icecast-metadata-js/src/icecast-metadata-js",
   "devDependencies": {
     "@types/jest": "^26.0.7",
     "jest": "^26.6.3",

--- a/src/icecast-metadata-js/src/AppendableBuffer.js
+++ b/src/icecast-metadata-js/src/AppendableBuffer.js
@@ -29,6 +29,20 @@ class AppendableBuffer {
     this._length = 0;
   }
 
+  /**
+   * @description Concatenates passed in buffers and returns a single buffer
+   * @param  {...Uint8Array} buffers
+   * @static
+   */
+  static appendBuffers(...buffers) {
+    return buffers.reduce(
+      (acc, buffer) => acc.append(buffer),
+      new AppendableBuffer(
+        buffers.reduce((acc, buffer) => acc + buffer.length, 0)
+      )
+    ).buffer;
+  }
+
   get length() {
     return this._length;
   }

--- a/src/icecast-metadata-js/src/AppendableBuffer.js
+++ b/src/icecast-metadata-js/src/AppendableBuffer.js
@@ -23,7 +23,7 @@ const bufferFunction = Buffer
 /**
  * @description Stores a collection of buffers as an array.
  */
-class MetadataBuffer {
+class AppendableBuffer {
   constructor(expectedLength) {
     this._buffer = bufferFunction(expectedLength);
     this._length = 0;
@@ -33,17 +33,15 @@ class MetadataBuffer {
     return this._length;
   }
 
-  /**
-   * @type {Uint8Array} Returns all stored data
-   */
-  pop() {
+  get buffer() {
     return this._buffer;
   }
 
-  push(data) {
+  append(data) {
     this._buffer.set(data, this._length);
     this._length += data.length;
+    return this;
   }
 }
 
-module.exports = MetadataBuffer;
+module.exports = AppendableBuffer;

--- a/src/icecast-metadata-js/src/IcecastMetadataReader.js
+++ b/src/icecast-metadata-js/src/IcecastMetadataReader.js
@@ -210,22 +210,21 @@ class IcecastMetadataReader {
   }
 
   *_generator() {
-    this._icyMetaInt =
-      this._icyMetaInt > 0
-        ? this._icyMetaInt
-        : yield* this._detectMetadataInterval();
+    if (!(this._icyMetaInt > 0)) {
+      this._icyMetaInt = yield* this._detectMetadataInterval();
 
-    if (this._icyMetaInt) {
-      do {
-        yield* this._getStream(this._icyMetaInt);
-        yield* this._getMetadataLength();
-        if (this._remainingData) yield* this._getMetadata();
-      } while (true);
-    } else {
-      do {
-        yield* this._getStream(this._buffer.length);
-      } while (true);
+      if (!this._icyMetaInt) {
+        do {
+          yield* this._getStream(this._buffer.length);
+        } while (true);
+      }
     }
+
+    do {
+      yield* this._getStream(this._icyMetaInt);
+      yield* this._getMetadataLength();
+      if (this._remainingData) yield* this._getMetadata();
+    } while (true);
   }
 
   *_getStream(remainingData) {

--- a/src/icecast-metadata-js/src/IcecastMetadataReader.js
+++ b/src/icecast-metadata-js/src/IcecastMetadataReader.js
@@ -42,36 +42,36 @@ class Stats {
     };
   }
 
-  set addStreamBytes(bytes) {
-    this._streamBytesRead += bytes;
-    this._totalBytesRead += bytes;
-    this._currentStreamBytesRemaining -= bytes;
-    this._currentBytesRemaining -= bytes;
-  }
-
-  set addMetadataLengthBytes(bytes) {
-    this._metadataLengthBytesRead += bytes;
-    this._totalBytesRead += bytes;
-    this._currentBytesRemaining -= bytes;
-  }
-
-  set addMetadataBytes(bytes) {
-    this._metadataBytesRead += bytes;
-    this._totalBytesRead += bytes;
-    this._currentMetadataBytesRemaining -= bytes;
-    this._currentBytesRemaining -= bytes;
-  }
-
-  set addCurrentBytesRemaining(bytes) {
-    this._currentBytesRemaining += bytes;
-  }
-
   set currentStreamBytesRemaining(bytes) {
     this._currentStreamBytesRemaining = bytes;
   }
 
   set currentMetadataBytesRemaining(bytes) {
     this._currentMetadataBytesRemaining = bytes;
+  }
+
+  addStreamBytes(bytes) {
+    this._streamBytesRead += bytes;
+    this._totalBytesRead += bytes;
+    this._currentStreamBytesRemaining -= bytes;
+    this._currentBytesRemaining -= bytes;
+  }
+
+  addMetadataLengthBytes(bytes) {
+    this._metadataLengthBytesRead += bytes;
+    this._totalBytesRead += bytes;
+    this._currentBytesRemaining -= bytes;
+  }
+
+  addMetadataBytes(bytes) {
+    this._metadataBytesRead += bytes;
+    this._totalBytesRead += bytes;
+    this._currentMetadataBytesRemaining -= bytes;
+    this._currentBytesRemaining -= bytes;
+  }
+
+  addCurrentBytesRemaining(bytes) {
+    this._currentBytesRemaining += bytes;
   }
 }
 
@@ -285,7 +285,7 @@ class IcecastMetadataReader {
 
     do {
       const stream = yield* this._getNextValue();
-      this._stats.addStreamBytes = stream.length;
+      this._stats.addStreamBytes(stream.length);
 
       const streamPayload = { stream, stats: this._stats.stats };
 
@@ -301,7 +301,7 @@ class IcecastMetadataReader {
       this._remainingData = (yield* this._getNextValue())[0] * 16;
     } while (this._remainingData === 1);
 
-    this._stats.addMetadataLengthBytes = 1;
+    this._stats.addMetadataLengthBytes(1);
   }
 
   *_getMetadata() {
@@ -312,7 +312,7 @@ class IcecastMetadataReader {
       metadataBuffer.append(yield* this._getNextValue());
     } while (this._remainingData); // store any partial metadata updates
 
-    this._stats.addMetadataBytes = metadataBuffer.length;
+    this._stats.addMetadataBytes(metadataBuffer.length);
 
     const metadataPayload = {
       metadata: this.parseMetadata(metadataBuffer.buffer),
@@ -346,7 +346,7 @@ class IcecastMetadataReader {
       data = yield; // if out of data, accept new data in the .next() call
     } while (!data || data.length === 0);
 
-    this._stats.addCurrentBytesRemaining = data.length;
+    this._stats.addCurrentBytesRemaining(data.length);
     return data;
   }
 }

--- a/src/icecast-metadata-js/src/IcecastMetadataStream.js
+++ b/src/icecast-metadata-js/src/IcecastMetadataStream.js
@@ -20,12 +20,13 @@ const IcecastMetadataReader = require("./IcecastMetadataReader");
 
 /**
  * @description NodeJS streams wrapper for IcecastMetadataReader
- * @param {Object} IcecastMetadataStream constructor parameter
+ * @param {object} IcecastMetadataStream constructor parameter
  * @param {number} IcecastMetadataStream.icyMetaInt Interval in bytes of metadata updates returned by the Icecast server
- * @param {number} IcecastMetadataStream.icyBr Bitrate of audio stream used to increase accuracy when to updating metadata
+ * @param {number} IcecastMetadataStream.icyBr Bitrate of audio stream used to increase accuracy when updating metadata
+ * @param {number} IcecastMetadataStream.icyDetectionTimeout Duration in milliseconds to search for metadata if icyMetaInt isn't passed in
  */
 class IcecastMetadataStream extends Writable {
-  constructor({ icyMetaInt, icyBr }) {
+  constructor({ icyMetaInt, icyBr, icyDetectionTimeout }) {
     super();
     this._icyBr = icyBr;
 
@@ -34,6 +35,7 @@ class IcecastMetadataStream extends Writable {
 
     this._generator = new IcecastMetadataReader({
       icyMetaInt,
+      icyDetectionTimeout,
       onStream: (value) => this._handleStream(value),
       onMetadata: (value) => this._handleMetadata(value),
     });

--- a/src/icecast-metadata-js/src/IcecastReadableStream.js
+++ b/src/icecast-metadata-js/src/IcecastReadableStream.js
@@ -30,7 +30,10 @@ export default class IcecastReadableStream extends ReadableStream {
    * @param {object} options Configuration options for IcecastMetadataReader
    * @see IcecastMetadataReader for information on the options parameter
    */
-  constructor(response, { icyMetaInt, onStream = noOp, onMetadata }) {
+  constructor(
+    response,
+    { icyMetaInt, icyDetectionTimeout, onStream = noOp, onMetadata }
+  ) {
     const readerIterator = IcecastReadableStream.asyncIterator(response.body);
 
     super({
@@ -38,6 +41,7 @@ export default class IcecastReadableStream extends ReadableStream {
         const icecast = new IcecastMetadataReader({
           icyMetaInt:
             parseInt(response.headers.get("Icy-MetaInt")) || icyMetaInt,
+          icyDetectionTimeout,
           onMetadata,
           onStream: (value) => {
             controller.enqueue(value.stream);


### PR DESCRIPTION
## Features
* Attempt to detect ICY metadata if the `Icy-MetaInt` is not passed in on instantiation to work around inadequate CORS configuration
* Add `icyDetectionTimeout` parameter
  * Limits the ICY metadata detection step to last around *n* milliseconds (defaults to 2000)
* ICY metadata detection is disabled if `icyDetectionTimeout` is set to 0 or if `icyMetaInt` is valid (i.e. > 0)

Resolves #29 