### PR TITLE
fix: allow for some ogg syncing for 'invalid' ogg streams

### DIFF
--- a/src/icecast-metadata-js/package-lock.json
+++ b/src/icecast-metadata-js/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "icecast-metadata-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.0",
+      "version": "0.3.1",
       "license": "LGPL-3.0-or-later",
       "devDependencies": {
         "@types/jest": "^26.0.19",

--- a/src/icecast-metadata-js/package.json
+++ b/src/icecast-metadata-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icecast-metadata-js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Library for Web Browsers and NodeJS that reads, parses, and synchronizes Icecast stream metadata",
   "keywords": [
     "icecast",


### PR DESCRIPTION
* Keeps Ogg metadata working even if there is some out of band data in an otherwise normal Ogg stream.
* Syncs up to the max size of an Ogg page (65307 bytes), then gives up.