### PR TITLE
fix(icecast-metadata-js) Infinite loop in ogg metadata parser

### DIFF
--- a/src/icecast-metadata-js/package-lock.json
+++ b/src/icecast-metadata-js/package-lock.json
@@ -1,11 +1,11 @@
 {
   "name": "icecast-metadata-js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "version": "0.3.1",
+      "version": "0.3.2",
       "license": "LGPL-3.0-or-later",
       "devDependencies": {
         "@types/jest": "^26.0.19",

--- a/src/icecast-metadata-js/package.json
+++ b/src/icecast-metadata-js/package.json
@@ -1,6 +1,6 @@
 {
   "name": "icecast-metadata-js",
-  "version": "0.3.1",
+  "version": "0.3.2",
   "description": "Library for Web Browsers and NodeJS that reads, parses, and synchronizes Icecast stream metadata",
   "keywords": [
     "icecast",

--- a/src/icecast-metadata-js/src/MetadataParser/MetadataParser.js
+++ b/src/icecast-metadata-js/src/MetadataParser/MetadataParser.js
@@ -136,7 +136,11 @@ class MetadataParser {
     );
 
     this._stats.addBytes(value.length);
-    this._remainingData -= value.length;
+    this._remainingData =
+      value.length < this._remainingData
+        ? this._remainingData - value.length
+        : 0;
+
     this._currentPosition += value.length;
 
     return value;


### PR DESCRIPTION
* Fix infinite loop condition in ogg metadata parser that occurs when the remaining data goes negative.