### PR TITLE
Add umd as `libraryTarget`

### DIFF
--- a/src/icecast-metadata-player/package.json
+++ b/src/icecast-metadata-player/package.json
@@ -17,7 +17,7 @@
     "update-version": "rm -f ../demo/public/*.js ../demo/public/*.map && find ./ ../demo -name '.map' -prune -o -name '.git' -prune -o -name 'node_modules' -prune -o -name 'build' -prune -o -name 'package*' -prune -o -type f -printf '\\n%p:' -exec sed -i \"s/icecast-metadata-player-[0-9].[0-9].[0-9]/icecast-metadata-player-$npm_package_version/g w /dev/fd/2\" \"{}\" \\; && cp ./build/*.js ./build/*.map ../demo/public/",
     "build": "rm -f ./build/* && webpack && npm run update-version"
   },
-  "browser": "./src/IcecastMetadataPlayer.js",
+  "browser": "/build/umd/icecast-metadata-player-1.0.0.min.js",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/eshaz/icecast-metadata-js.git"

--- a/src/icecast-metadata-player/webpack.config.js
+++ b/src/icecast-metadata-player/webpack.config.js
@@ -23,7 +23,7 @@ const license = `
  * along with this program.  If not, see <https://www.gnu.org/licenses/>
 `;
 
-module.exports = {
+const baseConfig  = {
   mode: "production",
   devtool: "source-map",
   entry: "/src/IcecastMetadataPlayer.js",
@@ -59,3 +59,43 @@ module.exports = {
     ],
   },
 };
+
+
+const umdConfig  = {
+  mode: "production",
+  devtool: "source-map",
+  entry: "/src/IcecastMetadataPlayer.js",
+  output: {
+    path: __dirname + "/build/umd",
+    filename: `${package.name}-${package.version}.min.js`,
+    libraryTarget: "umd",
+    library: "IcecastMetadataPlayer",
+  },
+  plugins: [new webpack.ProgressPlugin()],
+  resolve: {
+    fallback: { util: false },
+  },
+  module: {
+    rules: [],
+  },
+  optimization: {
+    minimize: true,
+    minimizer: [
+      new TerserPlugin({
+        extractComments: {
+          condition: true,
+          banner: () => license,
+        },
+        terserOptions: {
+          mangle: {
+            properties: {
+              regex: /^_/,
+            },
+          },
+        },
+      }),
+    ],
+  },
+};
+
+module.exports = [baseConfig, umdConfig];


### PR DESCRIPTION
This pull request is not complete, I'm creating it so that we have a reference.

This enables an import of 'icecast-metadata-player' with:
`import IcecastMetadataPlayer from 'icecast-metadata-player'` with webpack.

I added a webpack configuration using `output.libraryTarget = 'umd'`, and exported it toghether with the `output.libraryTarget = 'var'` one.

Without this configuration webpack returns `process is not defined` runtime error.

### Module Resolution with different Library Targets
I'm not very experienced on building modules, was trying to find a way to make the automatic selection of target, but failing.

Changed also the `package.json.browser` property to the dist file, so that module resolution will point to that.