### PR TITLE
Decoder encoding fix

### DIFF
--- a/src/demo/src/App.js
+++ b/src/demo/src/App.js
@@ -69,6 +69,7 @@ const App = () => {
           setMetadata(station.metadataTypes.length ? CONNECTED : "");
         },
         icyDetectionTimeout: 5000,
+        decoderEncoding: "utf-8",
         enableLogging: true,
         metadataTypes: station.metadataTypes,
         audioElement,

--- a/src/icecast-metadata-js/src/IcecastReadableStream.js
+++ b/src/icecast-metadata-js/src/IcecastReadableStream.js
@@ -28,7 +28,7 @@ export default class IcecastReadableStream {
    * @param {object} options Configuration options for IcecastMetadataReader
    * @see IcecastMetadataReader for information on the options parameter
    */
-  constructor(response, { icyMetaInt, onStream = noOp, ...rest }) {
+  constructor(response, { icyMetaInt, decoderEncoding, onStream = noOp, ...rest }) {
     let icecast;
 
     this._readableStream = new ReadableStream({
@@ -37,6 +37,7 @@ export default class IcecastReadableStream {
           ...rest,
           icyMetaInt:
             parseInt(response.headers.get("Icy-MetaInt")) || icyMetaInt,
+          decoderEncoding: decoderEncoding,
           onStream: async (value) => {
             controller.enqueue(value.stream);
             return onStream(value);

--- a/src/icecast-metadata-js/src/MetadataParser/MetadataParser.js
+++ b/src/icecast-metadata-js/src/MetadataParser/MetadataParser.js
@@ -32,7 +32,7 @@ class MetadataParser {
     this._currentPosition = 0;
     this._buffer = new Uint8Array(0);
     this._stats = new Stats();
-    this._decoder = new Decoder("utf-8");
+    this._decoder = new Decoder(params.decoderEncoding || "utf-8");
 
     this._onStream = params.onStream || noOp;
     this._onMetadata = params.onMetadata || noOp;

--- a/src/icecast-metadata-player/src/IcecastMetadataPlayer.js
+++ b/src/icecast-metadata-player/src/IcecastMetadataPlayer.js
@@ -36,6 +36,7 @@ import {
   retryDelayMax,
   retryDelayRate,
   retryTimeout,
+  decoderEncoding,
   // methods
   fireEvent,
   attachAudioElement,
@@ -94,6 +95,7 @@ export default class IcecastMetadataPlayer extends EventClass {
    * @param {number} options.retryDelayMax Maximum number of seconds between retries (end of the exponential back-off curve)
    * @param {boolean} options.enableLogging Set to `true` to enable warning and error logging to the console
    * @param {string} options.playbackMethod Sets the preferred playback method (mediasource (default), html5, webaudio)
+   * @param {string} options.decoderEncoding Sets the preferred decoder encoding (default: utf-8)
    *
    * @callback options.onMetadata Called with metadata when synchronized with the audio
    * @callback options.onMetadataEnqueue Called with metadata when discovered on the response
@@ -128,6 +130,7 @@ export default class IcecastMetadataPlayer extends EventClass {
       [retryDelayMax]: (options.retryDelayMax || 2) * 1000,
       [retryTimeout]: (options.retryTimeout || 30) * 1000,
       [playbackMethod]: options.playbackMethod,
+      [decoderEncoding]: options.decoderEncoding,
       // callbacks
       [events]: {
         [event.PLAY]: options.onPlay || noOp,

--- a/src/icecast-metadata-player/src/IcecastMetadataPlayer.js
+++ b/src/icecast-metadata-player/src/IcecastMetadataPlayer.js
@@ -230,7 +230,8 @@ export default class IcecastMetadataPlayer extends EventClass {
 
     p.get(this)[playerFactory] = new PlayerFactory(
       this,
-      p.get(this)[playbackMethod]
+      p.get(this)[playbackMethod],
+      p.get(this)[decoderEncoding]
     );
   }
 

--- a/src/icecast-metadata-player/src/PlayerFactory.js
+++ b/src/icecast-metadata-player/src/PlayerFactory.js
@@ -13,6 +13,7 @@ import {
   fireEvent,
   hasIcy,
   abortController,
+  decoderEncoding,
 } from "./global.js";
 
 import Player from "./players/Player.js";
@@ -34,6 +35,8 @@ export default class PlayerFactory {
     this._icyDetectionTimeout = instanceVariables[icyDetectionTimeout];
 
     this._hasIcy = instanceVariables[hasIcy];
+    
+    this._decoderEncoding = instanceVariables[decoderEncoding];
 
     this._preferredPlaybackMethod = preferredPlaybackMethod || "mediasource";
     this._playbackMethod = "";
@@ -115,6 +118,7 @@ export default class PlayerFactory {
         }
       },
       onError: (...args) => this._icecast[fireEvent](event.WARN, ...args),
+      decoderEncoding: this._decoderEncoding,
       metadataTypes: this._metadataTypes,
       icyMetaInt: this._icyMetaInt,
       icyDetectionTimeout: this._icyDetectionTimeout,

--- a/src/icecast-metadata-player/src/global.js
+++ b/src/icecast-metadata-player/src/global.js
@@ -37,6 +37,7 @@ export const retryDelayMin = Symbol();
 export const retryDelayMax = Symbol();
 export const retryTimeout = Symbol();
 export const enableCodecUpdate = Symbol();
+export const decoderEncoding = Symbol();
 
 // methods
 export const fireEvent = Symbol();

--- a/src/icecast-metadata-player/types/icecast-metadata-player.d.ts
+++ b/src/icecast-metadata-player/types/icecast-metadata-player.d.ts
@@ -109,6 +109,9 @@ declare module "icecast-metadata-player" {
      */
     retryDelayMax?: number;
 
+    /** The metadata character decoder encoding */
+    decoderEncoding?: string;
+
     /**
      * Set to `true` to enable warning and error logging to the console
      * @default false


### PR DESCRIPTION
Some Icecast versions could send different kinds of character sets than UTF-8 which could happen because of the source of the stream or the Icecast configuration. 
To be able to use different kinds of character sets, we could set the decoderEncoding parameter in the IcecastMetadataPlayer constructor from now.
By default, it stays as UTF-8.